### PR TITLE
early return for current path

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -68,6 +68,8 @@ const Sidebar = () => {
   }, [path]);
 
   const handleLinkClick = (clickedPath: string) => {
+    if (chosenPath === clickedPath) return;
+
     setIsLoading(true);
     setChosenPath(clickedPath);
     if (isMobile) {


### PR DESCRIPTION
Previously it was possible to click the same link and loading indicator showed up with infinite animation.