### PR TITLE
hide icon on large screen on first render

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -123,7 +123,7 @@ const Sidebar = () => {
       )}
 
       {/* closed sidebar */}
-      {!isOpen && (
+      {!isOpen && isMobile && (
         <button
           className="flex justify-center items-center fixed z-10 bottom-2 left-2 p-2 border-r border-t border-b border-input rounded-full bg-primary text-white"
           onClick={() => setIsOpen(true)}


### PR DESCRIPTION
prevents the icon intended for mobile from appearing on first render on large screen